### PR TITLE
Save reaction multiplicity to network

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ draw = [
     "pygraphviz",
 ]
 lint = [
-    "mypy",
+    "mypy<=1.15",
     "ruff<=0.7.3",
 ]
 profile = [

--- a/src/doranet/core/network/_network.py
+++ b/src/doranet/core/network/_network.py
@@ -264,7 +264,7 @@ class ChemNetworkBasic(interfaces.ChemNetwork):
         "_op_query",
         "_rxn_query",
         "_reactive_list",
-        "save_multiplicity",
+        "_save_multiplicity",
     )
 
     def __init__(self) -> None:
@@ -298,7 +298,7 @@ class ChemNetworkBasic(interfaces.ChemNetwork):
         ] = None
 
         self._reactive_list: list[bool] = []
-        self.save_multiplicity: bool = True
+        self._save_multiplicity: bool = True
 
     @property
     def mols(
@@ -492,7 +492,7 @@ class ChemNetworkBasic(interfaces.ChemNetwork):
         if rxn in self._rxn_map:
             rxn_index = self._rxn_map[rxn]
             # Increment the multiplicity counter in the metadata
-            if self.save_multiplicity:
+            if self._save_multiplicity:
                 existing_meta = self._rxn_meta[rxn_index]
                 existing_meta["multiplicity"] = (
                     existing_meta.get("multiplicity", 1) + 1)
@@ -529,7 +529,7 @@ class ChemNetworkBasic(interfaces.ChemNetwork):
             self._mol_producers[i].append(rxn_index)
 
         # add rxn metadata to table
-        if self.save_multiplicity:
+        if self._save_multiplicity:
             if meta is None:
                 new_meta = {"multiplicity": 1}
             else:

--- a/src/doranet/core/network/_network.py
+++ b/src/doranet/core/network/_network.py
@@ -536,11 +536,10 @@ class ChemNetworkBasic(interfaces.ChemNetwork):
                 new_meta = dict(meta)
                 new_meta["multiplicity"] = 1
             self._rxn_meta.append(new_meta)
+        elif meta is None:
+            self._rxn_meta.append({})
         else:
-            if meta is None:
-                self._rxn_meta.append({})
-            else:
-                self._rxn_meta.append(dict(meta))
+            self._rxn_meta.append(dict(meta))
 
         return rxn_index
 

--- a/src/doranet/core/network/_network.py
+++ b/src/doranet/core/network/_network.py
@@ -495,7 +495,8 @@ class ChemNetworkBasic(interfaces.ChemNetwork):
             if self._save_multiplicity:
                 existing_meta = self._rxn_meta[rxn_index]
                 existing_meta["multiplicity"] = (
-                    existing_meta.get("multiplicity", 1) + 1)
+                    existing_meta.get("multiplicity", 1) + 1
+                )
             if meta is not None:
                 self._rxn_meta[rxn_index].update(meta)
             return rxn_index

--- a/src/doranet/core/strategies/_strategies.py
+++ b/src/doranet/core/strategies/_strategies.py
@@ -1381,7 +1381,7 @@ class CartesianStrategyUpdated:
         # max_gen: typing.Optional[int] = None,
         save_multiplicity: bool = False,
     ):
-        self._network.save_multiplicity = save_multiplicity
+        self._network._save_multiplicity = save_multiplicity
         engine = self._engine
         p_strat = engine.strat.pq(self._network)
         # mol_filter: typing.Optional[interfaces.MolFilter] = None

--- a/src/doranet/core/strategies/_strategies.py
+++ b/src/doranet/core/strategies/_strategies.py
@@ -1379,7 +1379,9 @@ class CartesianStrategyUpdated:
         ] = None,
         save_unreactive: bool = True,
         # max_gen: typing.Optional[int] = None,
+        save_multiplicity: bool = False,
     ):
+        self._network.save_multiplicity = save_multiplicity
         engine = self._engine
         p_strat = engine.strat.pq(self._network)
         # mol_filter: typing.Optional[interfaces.MolFilter] = None


### PR DESCRIPTION
Created an option for saving reaction multiplicity (the number of duplicate reactions of a reaction) to network.