### PR TITLE
Update dependencies and linter checks

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -36,6 +36,7 @@ jobs:
           ruff check --output-format=github .
           ruff format --diff .
       - name: Type check with Mypy
+        if: ${{ matrix.os }} != "windows"
         run: |
           pip install .[lint]
           mypy --no-install-types .

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         os: [macos, ubuntu, windows]
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -36,7 +36,7 @@ jobs:
           ruff check --output-format=github .
           ruff format --diff .
       - name: Type check with Mypy
-        if: ${{ matrix.os }} != "windows"
+        if: ${{ matrix.os != 'windows' }}
         run: |
           pip install .[lint]
           mypy --no-install-types .

--- a/doranet/datatypes.py
+++ b/doranet/datatypes.py
@@ -87,7 +87,7 @@ class MolDatBasicV1(interfaces.MolDatRDKit):
 
     @property
     def rdkitmol(self) -> rdkit.Chem.rdchem.Mol:
-        return rdkit.Chem.rdchem.Mol(self._blob)
+        return rdkit.Chem.rdchem.Mol(self._blob)  # type: ignore[call-overload,unused-ignore]
 
     @property
     def smiles(self) -> str:
@@ -283,7 +283,7 @@ class OpDatBasic(interfaces.OpDatRDKit):
         self, mols: collections.abc.Iterable[rdkit.Chem.rdchem.Mol]
     ) -> collections.abc.Iterable[rdkit.Chem.rdchem.Mol]:
         try:
-            return self._rdkitrxn.RunReactants(mols, maxProducts=0)
+            return self._rdkitrxn.RunReactants(tuple(mols), maxProducts=0)
         except Exception as err:
             print(type(err))
             raise err

--- a/doranet/engine.py
+++ b/doranet/engine.py
@@ -250,11 +250,14 @@ class NetworkEngineBasic(interfaces.NetworkEngine):
         with gzip.open(filepath, "r") as fin:
             md = xml.dom.minidom
             data = md.parse(fin).documentElement
+            assert data is not None
             version = int(data.getAttribute("version"))
             if version == 0:
                 subversion = int(data.getAttribute("subversion"))
                 if subversion == 0:
-                    bvals = base64.urlsafe_b64decode(data.firstChild.data)
+                    fc = data.firstChild
+                    fc_data = fc.data  # type: ignore[union-attr]
+                    bvals = base64.urlsafe_b64decode(fc_data)
                     network: interfaces.ChemNetwork = pickle.loads(bvals)
                     return network
                 else:

--- a/doranet/interfaces.py
+++ b/doranet/interfaces.py
@@ -254,7 +254,8 @@ class MolDatRDKit(MolDatBase):
         pickaxe_generic.interfaces.MolDatRDKit
             Molecule returned from processing bytestring.
         """
-        return engine.mol.rdkit(rdkit.Chem.rdchem.Mol(data), sanitize=False)
+        mol: rdkit.Chem.rdchem.Mol = rdkit.Chem.rdchem.Mol(data)  # type: ignore[call-overload,unused-ignore]
+        return engine.mol.rdkit(mol, sanitize=False)
 
     @property
     @abc.abstractmethod
@@ -302,7 +303,7 @@ class MolDatRDKit(MolDatBase):
         neutralize: bool = False,
     ) -> rdkit.Chem.rdchem.Mol:
         if isinstance(molecule, bytes):
-            rdkitmol = rdkit.Chem.rdchem.Mol(molecule)
+            rdkitmol = rdkit.Chem.rdchem.Mol(molecule)  # type: ignore[call-overload,unused-ignore]
             # if sanitize:
             #    SanitizeMol(rdkitmol)
             #    AssignStereochemistry(rdkitmol, True, True, True)
@@ -2924,7 +2925,10 @@ class MolecularFormula:
         self._internalarray[i] = value
 
     def __add__(self, other: "MolecularFormula") -> "MolecularFormula":
-        return MolecularFormula(self._internalarray + other._internalarray)
+        sum_arr: numpy.ndarray[tuple[int], numpy.dtype[numpy.uintp]] = (
+            self._internalarray + other._internalarray
+        )
+        return MolecularFormula(sum_arr)
 
     def __hash__(self) -> int:
         return hash(dataclasses.astuple(self))

--- a/doranet/interfaces.py
+++ b/doranet/interfaces.py
@@ -1049,6 +1049,9 @@ class Recipe:
             return True
         return other.reactants < self.reactants
 
+    def __hash__(self) -> int:
+        return hash(dataclasses.astuple(self))
+
 
 @typing.final
 @dataclasses.dataclass(frozen=True, slots=True)
@@ -2499,6 +2502,9 @@ class RankValue(typing.Protocol):
             Whether `self` is equivalent to `other`.
         """
 
+    @abc.abstractmethod
+    def __hash__(self) -> int: ...
+
 
 class SizedTuple(tuple[typing.Optional[RankValue], ...]):
     __slots__ = ()
@@ -2523,6 +2529,9 @@ class SizedTuple(tuple[typing.Optional[RankValue], ...]):
         raise NotImplementedError(
             f"Comparison between {type(self)} and {type(other)} not supported."
         )
+
+    def __hash__(self) -> int:
+        return super().__hash__()
 
 
 class RecipeRanker(abc.ABC, typing.Generic[T_rank]):
@@ -2916,3 +2925,6 @@ class MolecularFormula:
 
     def __add__(self, other: "MolecularFormula") -> "MolecularFormula":
         return MolecularFormula(self._internalarray + other._internalarray)
+
+    def __hash__(self) -> int:
+        return hash(dataclasses.astuple(self))

--- a/doranet/interfaces.py
+++ b/doranet/interfaces.py
@@ -303,7 +303,7 @@ class MolDatRDKit(MolDatBase):
         neutralize: bool = False,
     ) -> rdkit.Chem.rdchem.Mol:
         if isinstance(molecule, bytes):
-            rdkitmol = rdkit.Chem.rdchem.Mol(molecule)  # type: ignore[call-overload,unused-ignore]
+            rdkitmol = rdkit.Chem.rdchem.Mol(molecule)  # type: ignore[arg-type,call-overload,unused-ignore]
             # if sanitize:
             #    SanitizeMol(rdkitmol)
             #    AssignStereochemistry(rdkitmol, True, True, True)

--- a/doranet/interfaces.py
+++ b/doranet/interfaces.py
@@ -2926,7 +2926,7 @@ class MolecularFormula:
 
     def __add__(self, other: "MolecularFormula") -> "MolecularFormula":
         sum_arr: numpy.ndarray[tuple[int], numpy.dtype[numpy.uintp]] = (
-            self._internalarray + other._internalarray
+            self._internalarray + other._internalarray  # type: ignore[assignment, unused-ignore]
         )
         return MolecularFormula(sum_arr)
 

--- a/doranet/metacalc.py
+++ b/doranet/metacalc.py
@@ -119,7 +119,7 @@ class MassWasteCalculator(metadata.MolPropertyFromRxnCalc[float]):
 
 @typing.final
 @dataclasses.dataclass(frozen=True, slots=True)
-class MolWeightCalculator(metadata.MolPropertyCalc[int]):
+class MolWeightCalculator(metadata.MolPropertyCalc[float]):
     weight_key: collections.abc.Hashable
 
     @property
@@ -131,14 +131,14 @@ class MolWeightCalculator(metadata.MolPropertyCalc[int]):
         return interfaces.MetaKeyPacket()
 
     @property
-    def resolver(self) -> metadata.MetaDataResolverFunc[int]:
+    def resolver(self) -> metadata.MetaDataResolverFunc[float]:
         return metadata.TrivialMetaDataResolverFunc
 
     def __call__(
         self,
         data: interfaces.DataPacketE[interfaces.MolDatBase],
-        prev_value: typing.Optional[int] = None,
-    ) -> typing.Optional[int]:
+        prev_value: typing.Optional[float] = None,
+    ) -> typing.Optional[float]:
         if prev_value is not None:
             return prev_value
         item = data.item

--- a/doranet/metadata.py
+++ b/doranet/metadata.py
@@ -175,22 +175,25 @@ class KeyOutput:
         new_mol_keys = self.mol_keys | other.mol_keys
         if len(new_mol_keys) > len(self.mol_keys) + len(other.mol_keys):
             raise KeyError(
-                f"""Conflicting molecule metadata key outputs {self.mol_keys &
-                    other.mol_keys}; separate expressions with >> or combine
+                f"""Conflicting molecule metadata key outputs {
+                    self.mol_keys & other.mol_keys
+                }; separate expressions with >> or combine
                     using other operator"""
             )
         new_op_keys = self.op_keys | other.op_keys
         if len(new_op_keys) > len(self.op_keys) + len(other.op_keys):
             raise KeyError(
-                f"""Conflicting operator metadata key outputs {self.op_keys &
-                    other.op_keys}; separate expressions with >> or combine
+                f"""Conflicting operator metadata key outputs {
+                    self.op_keys & other.op_keys
+                }; separate expressions with >> or combine
                     using other operator"""
             )
         new_rxn_keys = self.rxn_keys | other.rxn_keys
         if len(new_rxn_keys) > len(self.rxn_keys) + len(other.rxn_keys):
             raise KeyError(
-                f"""Conflicting reaction metadata key outputs {self.rxn_keys &
-                    other.rxn_keys}; separate expressions with >> or combine
+                f"""Conflicting reaction metadata key outputs {
+                    self.rxn_keys & other.rxn_keys
+                }; separate expressions with >> or combine
                     using other operator"""
             )
         return KeyOutput(new_mol_keys, new_op_keys, new_rxn_keys)

--- a/doranet/modules/enzymatic/generate_network.py
+++ b/doranet/modules/enzymatic/generate_network.py
@@ -2,6 +2,7 @@
 
 import collections.abc
 import dataclasses
+import math
 import re
 import time
 import typing
@@ -350,7 +351,7 @@ class Rxn_dH_Filter(metadata.ReactionFilterBase):
         dH = recipe.reaction_meta[self.dH_key]
         if dH == "No_Thermo":
             return True
-        if dH == float("nan"):
+        if math.isnan(dH):
             return False
         return dH < self.max_dH
 

--- a/doranet/modules/enzymatic/generate_network.py
+++ b/doranet/modules/enzymatic/generate_network.py
@@ -443,16 +443,12 @@ def generate_network(
     engine = dn.create_engine()
     network = engine.new_network()
 
-    for key in cofactors_dict:
+    for key, _keyitem in cofactors_dict.items():
         if excluded_cofactors is None or key not in excluded_cofactors:
             # add cofactors to network, they're like helpers in chem expansion
             network.add_mol(
-                engine.mol.rdkit(cofactors_dict[key]),
-                meta={
-                    "SMILES": Chem.MolToSmiles(
-                        Chem.MolFromSmiles(cofactors_dict[key])
-                    )
-                },
+                engine.mol.rdkit(_keyitem),
+                meta={"SMILES": Chem.MolToSmiles(Chem.MolFromSmiles(_keyitem))},
             )
 
     my_start_i = -1

--- a/doranet/modules/post_processing/post_processing.py
+++ b/doranet/modules/post_processing/post_processing.py
@@ -633,8 +633,11 @@ def pathway_finder(
         for pro in products:
             producers_dict[pro][rxn_idx] = products_weight[pro] / total_weight
 
-    for smiles in producers_dict:  # number of producers, used to reduce forks
-        producers_dict_len[smiles] = len(producers_dict[smiles])
+    for (
+        smiles,
+        _smiles_item,
+    ) in producers_dict.items():  # number of producers, used to reduce forks
+        producers_dict_len[smiles] = len(_smiles_item)
 
     distance_to_startrs_dict = dict()  # min distance to starters
     for smiles in starters_set:
@@ -1046,9 +1049,9 @@ def pathway_finder(
                         idx * max_rxns_per_batch :
                     ]
 
-            for key in output_dict:
+            for key, _keyitem in output_dict.items():
                 with open(key + ".txt", "w", encoding="utf-8") as f_result:
-                    for query in output_dict[key]:
+                    for query in _keyitem:
                         f_result.write("SMILES='" + query + "'")
                         f_result.write("\n")
         # Save a templet csv file, user can copy Reaxys query result over
@@ -1726,13 +1729,13 @@ def pathway_ranking(
         if timecount == timeout:
             return None
         by_product_weight = 0
-        for i in right_dict:
+        for i, _i_item in right_dict.items():
             if i in has_bio:
                 by_product_weight += 0
             else:
                 by_product_weight += (
                     Descriptors.MolWt(rdkit.Chem.rdmolfiles.MolFromSmiles(i))
-                    * right_dict[i]
+                    * _i_item
                 )
 
         to_return = target_weight / (target_weight + by_product_weight)

--- a/doranet/modules/post_processing/post_processing.py
+++ b/doranet/modules/post_processing/post_processing.py
@@ -560,7 +560,7 @@ def pathway_finder(
     starters_set = set(mol_smiles)
 
     print(
-        "Pathway finder started, " "total number of reactions in network",
+        "Pathway finder started, total number of reactions in network",
         len(data),
     )
 
@@ -1394,7 +1394,7 @@ def pathway_ranking(
     max_rxn_thermo_change=15,
 ):
     if not starters or not target:
-        raise Exception("Starters and target are" " needed to rank pathways")
+        raise Exception("Starters and target are needed to rank pathways")
 
     print(f"Job name: {job_name}")
     print("Job type: pathway ranking")

--- a/doranet/modules/post_processing/post_processing.py
+++ b/doranet/modules/post_processing/post_processing.py
@@ -1152,7 +1152,7 @@ class Rxn_dH_Filter(metadata.ReactionFilterBase):
         dH = recipe.reaction_meta[self.dH_key]
         if dH == "No_Thermo":
             return True
-        if dH == float("nan"):
+        if math.isnan(dH):
             return False
         return dH < self.max_dH
 

--- a/doranet/modules/synthetic/generate_network.py
+++ b/doranet/modules/synthetic/generate_network.py
@@ -2,6 +2,7 @@
 
 import collections.abc
 import dataclasses
+import math
 import re
 import time
 import typing
@@ -104,7 +105,7 @@ class Rxn_dH_Filter(metadata.ReactionFilterBase):
         dH = recipe.reaction_meta[self.dH_key]
         if dH == "No_Thermo":
             return True
-        if dH == float("nan"):
+        if math.isnan(dH):
             return False
         return dH < self.max_dH
 

--- a/doranet/strategies.py
+++ b/doranet/strategies.py
@@ -803,6 +803,9 @@ class RecipePriorityItem:
             and self.recipe == other.recipe
         )
 
+    def __hash__(self) -> int:
+        return hash(dataclasses.astuple(self))
+
 
 def execute_recipe_ranking(
     job: RecipeRankingJob,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,6 @@ warn_unused_configs = true
 
 [[tool.mypy.overrides]]
 ignore_missing_imports = true
-follow_imports = "skip"
 module = [
     "IPython.*",
     "networkx.*",
@@ -77,7 +76,6 @@ module = [
     "pgthermo.*",
     "PIL.*",
     "rdkit.*",
-    "rdkit-stubs.*",
 ]
 
 [tool.ruff]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = 'doranet'
-version = '0.5.6a1'
+version = '0.5.7a1'
 authors = [
     { name='William Sprague', email='wsprague@u.northwestern.edu' },
     { name='Quan Zhang', email='quanzhang@northwestern.edu' },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,7 @@ module = [
     "pgthermo.*",
     "PIL.*",
     "rdkit.*",
+    "rdkit-stubs.*",
 ]
 
 [tool.ruff]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,8 +44,8 @@ draw = [
     "pygraphviz",
 ]
 lint = [
-    "mypy",
-    "ruff",
+    "mypy==1.17",
+    "ruff==0.14",
 ]
 profile = [
     "scalene",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "pillow",
     "pyarrow",
     "pypdf",
-    "rdkit<=2023.9.5",
+    "rdkit",
     "scipy",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,7 @@ warn_unused_configs = true
 
 [[tool.mypy.overrides]]
 ignore_missing_imports = true
+follow_imports = "skip"
 module = [
     "IPython.*",
     "networkx.*",


### PR DESCRIPTION
Changes:
- removed rdkit fixed version dependency
- many hint adjustments for linting and typing in newer `mypy` and `ruff` versions
- changed type hint to reflect that the MolWeightCalculator actually has a `float` type instead of `int`