### PR TITLE
Fix missing multiplicity parameter, improve tutorial

### DIFF
--- a/docs/source/tutorials/Quick-Start.md
+++ b/docs/source/tutorials/Quick-Start.md
@@ -267,7 +267,8 @@ pathway_ranking(
                                       #  "atom_economy": 1,
                                       #  "salt_score": 0,
                                       #  "in_reaxys": 0,
-                                      #  "coolness": 0}
+                                      #  "coolness": 0,
+                                      #  "profit": 0},
     num_process=1,                    # Number of CPU processes
     reaxys_result_name=None,          # CSV filename.
     job_name="default_job_name",

--- a/src/doranet/modules/post_processing/post_processing.py
+++ b/src/doranet/modules/post_processing/post_processing.py
@@ -187,7 +187,9 @@ def pretreat_networks(
             reactants = rxn.reactants
             products = rxn.products
             operator = rxn.operator
-            reaction = dn.interfaces.Reaction(operator, reactants, products)
+            multiplicity = rxn.mult
+            reaction = dn.interfaces.Reaction(operator, reactants, products,
+                                              multiplicity)
             reaction_i = n.rxns.i(reaction)
             reaction_meta = n.rxns.meta(reaction_i)
             thermo_value = reaction_meta["dH"]

--- a/src/doranet/modules/post_processing/post_processing.py
+++ b/src/doranet/modules/post_processing/post_processing.py
@@ -188,8 +188,9 @@ def pretreat_networks(
             products = rxn.products
             operator = rxn.operator
             multiplicity = rxn.mult
-            reaction = dn.interfaces.Reaction(operator, reactants, products,
-                                              multiplicity)
+            reaction = dn.interfaces.Reaction(
+                operator, reactants, products, multiplicity
+            )
             reaction_i = n.rxns.i(reaction)
             reaction_meta = n.rxns.meta(reaction_i)
             thermo_value = reaction_meta["dH"]


### PR DESCRIPTION
1. Fixes a bug where the multiplicity parameter was missing when reading reactions from the network during post-processing.
2. Adds the "profit" ranking parameter in the Quick-Start tutorial.